### PR TITLE
Enable opening options page via toolbar icon click

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,3 @@
+chrome.action.onClicked.addListener((tab) => {
+  chrome.runtime.openOptionsPage();
+});


### PR DESCRIPTION
I modified background.js to listen for chrome.action.onClicked events. When your extension's toolbar icon is clicked, it now calls chrome.runtime.openOptionsPage() to display the options.html page.

This provides a more direct way for you to access the extension's settings, as requested in the issue.